### PR TITLE
Fix dropped packets in mpeg stream

### DIFF
--- a/caption/mpeg.h
+++ b/caption/mpeg.h
@@ -50,6 +50,7 @@ typedef struct {
     // Should probablly be a linked list
     size_t front;
     size_t latent;
+    size_t parse_marker;
     cea708_t cea708[MAX_REFRENCE_FRAMES];
 } mpeg_bitstream_t;
 


### PR DESCRIPTION
In mpeg_bitstream_parse, packet->status can be set to
LIBCAPTION_READY or LIBCAPTION_ERROR before we have parsed all of the data
within the bitstream buffer belonging to the packet.  If this happens,
then we were skipping over the remaining chunk the next time this
function was called.

Add a parse marker variable to the packet to keep track of our last
parsing position.