### PR TITLE
h264 avc/mp4: add support for parsing NALU

### DIFF
--- a/caption/mpeg.h
+++ b/caption/mpeg.h
@@ -63,6 +63,10 @@ void mpeg_bitstream_init(mpeg_bitstream_t* packet);
 size_t mpeg_bitstream_parse(mpeg_bitstream_t* packet, caption_frame_t* frame, const uint8_t* data, size_t size,
                             unsigned stream_type, double dts, double cts, rollup_state_machine* rsm,
                             popon_state_machine* psm);
+
+size_t mpeg_avc_bitstream_parse(mpeg_bitstream_t* packet, caption_frame_t* frame, const uint8_t* data, size_t size,
+                            unsigned stream_type, double dts, double cts, rollup_state_machine* rsm,
+                            popon_state_machine* psm, size_t nal_field_length_size);
 /*! \brief
     \param
 */


### PR DESCRIPTION
The h264 avc/mp4 format does not have a start code of 00 00 01, but
instead contains a fixed length NALU length field.  Knowledge of whether
or not to use this mode needs to be provided by the consumer of the
libcaption API, so add a new function to allow for this format.